### PR TITLE
works with non local file storages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ HGREV
 TAGS
 tests/media/adminfiles/*_q
 .tox/*
+*.un~
+*.pyc

--- a/adminfiles/models.py
+++ b/adminfiles/models.py
@@ -64,7 +64,11 @@ class FileUpload(models.Model):
         return self._get_dimensions()[1]
     
     def save(self, *args, **kwargs):
-        (mime_type, encoding) = mimetypes.guess_type(self.upload.path)
+        try:
+            uri = self.upload.path
+        except NotImplementedError:
+            uri = self.upload.url
+        (mime_type, encoding) = mimetypes.guess_type(uri)
         try:
             [self.content_type, self.sub_type] = mime_type.split('/')
         except:


### PR DESCRIPTION
Some file storage not implement path property. In that case now it will use url for guessing mimetype of uploaded file.
