### PR TITLE
Add Configurable Upload directories via settings

### DIFF
--- a/adminfiles/migrations/0001_initial.py
+++ b/adminfiles/migrations/0001_initial.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'FileUpload'
+        db.create_table('adminfiles_fileupload', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('upload_date', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('upload', self.gf('django.db.models.fields.files.FileField')(max_length=100)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(unique=True, max_length=100)),
+            ('description', self.gf('django.db.models.fields.CharField')(max_length=200, blank=True)),
+            ('content_type', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('sub_type', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal('adminfiles', ['FileUpload'])
+
+        # Adding model 'FileUploadReference'
+        db.create_table('adminfiles_fileuploadreference', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('upload', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['adminfiles.FileUpload'])),
+            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
+            ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
+        ))
+        db.send_create_signal('adminfiles', ['FileUploadReference'])
+
+        # Adding unique constraint on 'FileUploadReference', fields ['upload', 'content_type', 'object_id']
+        db.create_unique('adminfiles_fileuploadreference', ['upload_id', 'content_type_id', 'object_id'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'FileUploadReference', fields ['upload', 'content_type', 'object_id']
+        db.delete_unique('adminfiles_fileuploadreference', ['upload_id', 'content_type_id', 'object_id'])
+
+        # Deleting model 'FileUpload'
+        db.delete_table('adminfiles_fileupload')
+
+        # Deleting model 'FileUploadReference'
+        db.delete_table('adminfiles_fileuploadreference')
+
+
+    models = {
+        'adminfiles.fileupload': {
+            'Meta': {'ordering': "['upload_date', 'title']", 'object_name': 'FileUpload'},
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'sub_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'upload_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'adminfiles.fileuploadreference': {
+            'Meta': {'unique_together': "(('upload', 'content_type', 'object_id'),)", 'object_name': 'FileUploadReference'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'upload': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['adminfiles.FileUpload']"})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['adminfiles']

--- a/adminfiles/migrations/0002_auto__add_field_fileupload_upload_to.py
+++ b/adminfiles/migrations/0002_auto__add_field_fileupload_upload_to.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'FileUpload.upload_to'
+        db.add_column('adminfiles_fileupload', 'upload_to',
+                      self.gf('django.db.models.fields.CharField')(default='adminfiles', max_length='200'),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'FileUpload.upload_to'
+        db.delete_column('adminfiles_fileupload', 'upload_to')
+
+
+    models = {
+        'adminfiles.fileupload': {
+            'Meta': {'ordering': "['upload_date', 'title']", 'object_name': 'FileUpload'},
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'sub_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'upload_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'upload_to': ('django.db.models.fields.CharField', [], {'default': "'adminfiles'", 'max_length': "'200'"})
+        },
+        'adminfiles.fileuploadreference': {
+            'Meta': {'unique_together': "(('upload', 'content_type', 'object_id'),)", 'object_name': 'FileUploadReference'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'upload': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['adminfiles.FileUpload']"})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['adminfiles']

--- a/adminfiles/models.py
+++ b/adminfiles/models.py
@@ -31,7 +31,7 @@ def get_upload_dir(instance, filename):
 class FileUpload(models.Model):
     upload_date = models.DateTimeField(_('upload date'), auto_now_add=True)
     upload = models.FileField(_('file'), upload_to=get_upload_dir)
-    upload_to = models.CharField(max_length="200", choices= UPLOAD_DIRECTORIES, blank=False, null=False)
+    upload_to = models.CharField(max_length="200", choices= UPLOAD_DIRECTORIES, default=UPLOAD_DIRECTORIES[0][0], blank=False, null=False)
     title = models.CharField(_('title'), max_length=100)
     slug = models.SlugField(_('slug'), max_length=100, unique=True)
     description = models.CharField(_('description'), blank=True, max_length=200)


### PR DESCRIPTION
I dont know if you want any of this but I figured I'd share it. I did it for a specific need we had. 

Basically give the user a way to upload to different predetermined paths.

Ex Config in settings.py :

```
UPLOAD_DIRECTORIES = (
    ('path1', 'Path1'),
    ('path2', 'Path2'),
)
```

Those end up as options when adding a new file.

![screenshot from 2013-10-16 11 48 20](https://f.cloud.github.com/assets/372217/1343988/ad7da1de-367a-11e3-91de-fb8d97d4c7b5.png)

Im happy to flesh it out more if you'd like.
